### PR TITLE
Fix: Pass dynamic variables to ElevenLabs conversational agent

### DIFF
--- a/frontend/src/app/api/reference-call/route.ts
+++ b/frontend/src/app/api/reference-call/route.ts
@@ -30,7 +30,16 @@ export async function POST(request: NextRequest) {
     const callResponse = await client.conversationalAi.twilio.outboundCall({
       agentId: process.env.ELEVENLABS_AGENT_ID!,
       agentPhoneNumberId: process.env.ELEVENLABS_AGENT_PHONE_ID!,
-      toNumber: phoneNumber
+      toNumber: phoneNumber,
+      conversationInitiationClientData: {
+        dynamicVariables: {
+          candidate_name: candidateName,
+          reference_name: referenceName,
+          company_name: companyName || '',
+          role_title: roleTitle || '',
+          work_duration: workDuration || ''
+        }
+      }
     });
 
     console.log('ElevenLabs call initiated successfully:', {


### PR DESCRIPTION
- Add conversationInitiationClientData with dynamicVariables to outbound call API
- Variables now passed: candidate_name, reference_name, company_name, role_title, work_duration
- AI agent can now use {{candidate_name}}, {{reference_name}}, etc. in conversations
- Fixes issue where agent was using literal 'candidateName' instead of dynamic values
- Reference calls now properly personalized with form data