### PR TITLE
Add GraphicsMagick to Docker container for PDF processing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,9 @@ ENV NODE_ENV production
 # Uncomment the following line in case you want to disable telemetry during runtime.
 ENV NEXT_TELEMETRY_DISABLED 1
 
+# Install GraphicsMagick for PDF processing
+RUN apk add --no-cache graphicsmagick
+
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 


### PR DESCRIPTION
- Install graphicsmagick package in Alpine Linux production container
- Fixes CV PDF processing errors in production deployment
- Enables PDF to image conversion for document analysis
- Local development uses brew-installed GraphicsMagick, production uses apk package

This resolves the 'gm convert' command not found errors when processing CV uploads.